### PR TITLE
74 Can't Reference Exhaustive Model in Activation Rules 

### DIFF
--- a/Jube.App/Controllers/Helper/ParserController.cs
+++ b/Jube.App/Controllers/Helper/ParserController.cs
@@ -101,14 +101,18 @@ namespace Jube.App.Controllers.Helper
                 }
 
                 List<string> entityAnalysisModelAbstractionCalculations = null;
-                List<string> entityAnalysisModelsAdaptations = null;
+                List<string> entityAnalysisModelsHttpAdaptations = null;
+                List<string> entityAnalysisModelsExhaustiveAdaptations = null;
                 if (parseRuleRequestDto.RuleParseType > 4)
                 {
                     entityAnalysisModelAbstractionCalculations
                         = EntityAnalysisModelAbstractionCalculations(parseRuleRequestDto.EntityAnalysisModelId);
 
-                    entityAnalysisModelsAdaptations
-                        = EntityAnalysisModelsAdaptations(parseRuleRequestDto.EntityAnalysisModelId);
+                    entityAnalysisModelsHttpAdaptations
+                        = EntityAnalysisModelsHttpAdaptations(parseRuleRequestDto.EntityAnalysisModelId);
+
+                    entityAnalysisModelsExhaustiveAdaptations
+                        = EntityAnalysisModelsExhaustiveAdaptations(parseRuleRequestDto.EntityAnalysisModelId);
                 }
 
                 var parser = new Parser.Parser(_log,
@@ -122,7 +126,8 @@ namespace Jube.App.Controllers.Helper
                     EntityAnalysisModelsSanctions = entityAnalysisModelsSanctions,
                     EntityAnalysisModelsLists = entityAnalysisModelsLists,
                     EntityAnalysisModelsDictionaries = entityAnalysisModelsDictionaries,
-                    EntityAnalysisModelsAdaptations = entityAnalysisModelsAdaptations
+                    EntityAnalysisModelsHttpAdaptations = entityAnalysisModelsHttpAdaptations,
+                    EntityAnalysisModelsExhaustiveAdaptations = entityAnalysisModelsExhaustiveAdaptations
                 };
 
                 var errorSpans = new List<ErrorSpan>();
@@ -222,12 +227,22 @@ namespace Jube.App.Controllers.Helper
             }
         }
 
-        private List<string> EntityAnalysisModelsAdaptations(int entityAnalysisModelId)
+        private List<string> EntityAnalysisModelsHttpAdaptations(int entityAnalysisModelId)
         {
             var entityAnalysisModelHttpAdaptationRepository =
                 new EntityAnalysisModelHttpAdaptationRepository(_dbContext, _userName);
 
             return entityAnalysisModelHttpAdaptationRepository
+                .GetByEntityAnalysisModelIdOrderById(entityAnalysisModelId)
+                .Select(s => s.Name).ToList();
+        }
+
+        private List<string> EntityAnalysisModelsExhaustiveAdaptations(int entityAnalysisModelId)
+        {
+            var entityAnalysisModelExhaustiveRepository =
+                new ExhaustiveSearchInstanceRepository(_dbContext, _userName);
+
+            return entityAnalysisModelExhaustiveRepository
                 .GetByEntityAnalysisModelIdOrderById(entityAnalysisModelId)
                 .Select(s => s.Name).ToList();
         }

--- a/Jube.Data/Query/GetModelFieldByEntityAnalysisModelIdParseTypeIdQuery.cs
+++ b/Jube.Data/Query/GetModelFieldByEntityAnalysisModelIdParseTypeIdQuery.cs
@@ -209,10 +209,7 @@ public class GetModelFieldByEntityAnalysisModelIdParseTypeIdQuery
                         Group = "Abstraction",
                         ProcessingTypeId = 7
                     }));
-        }
 
-        if (parserTypeId >= 6)
-        {
             var entityAnalysisModelHttpAdaptationRepository =
                 new EntityAnalysisModelHttpAdaptationRepository(_dbContext, _tenantRegistryId);
 
@@ -220,13 +217,13 @@ public class GetModelFieldByEntityAnalysisModelIdParseTypeIdQuery
                 .GetByEntityAnalysisModelIdOrderById(entityAnalysisModelId).Select(s =>
                     new Dto
                     {
-                        Name = $"Adaptation.{s.Name}",
-                        Value = $"Adaptation.{s.Name}",
-                        ValueJsonPath = $"adaptation.{s.Name}",
-                        ValueSqlPath = $"(\"Json\"-> 'adaptation' ->> '{s.Name}')::double precision",
+                        Name = $"HTTPAdaptation.{s.Name}",
+                        Value = $"HTTPAdaptation.{s.Name}",
+                        ValueJsonPath = $"HttpAdaptation.{s.Name}",
+                        ValueSqlPath = $"(\"Json\"-> 'httpAdaptation' ->> '{s.Name}')::double precision",
                         DataTypeId = 3,
                         JQueryBuilderDataType = "double",
-                        Group = "Adaptation",
+                        Group = "HTTPAdaptation",
                         ProcessingTypeId = 7
                     }));
 
@@ -237,13 +234,14 @@ public class GetModelFieldByEntityAnalysisModelIdParseTypeIdQuery
                 .GetByEntityAnalysisModelIdOrderById(entityAnalysisModelId).Select(s =>
                     new Dto
                     {
-                        Name = $"Adaptation.{s.Name}",
-                        Value = $"Adaptation.{s.Name}",
-                        ValueJsonPath = $"adaptation.{s.Name}",
-                        ValueSqlPath = $"(\"Json\"-> 'adaptation' ->> '{s.Name}')::double precision",
+                        Name = $"ExhaustiveAdaptation.{s.Name}",
+                        Value = $"ExhaustiveAdaptation.{s.Name}",
+                        ValueJsonPath = $"ExhaustiveAdaptation.{s.Name}",
+                        ValueSqlPath = $"(\"Json\"-> 'exhaustiveAdaptation' ->> '{s.Name}')::double precision",
                         DataTypeId = 3,
                         JQueryBuilderDataType = "double",
-                        Group = "Adaptation"
+                        Group = "ExhaustiveAdaptation",
+                        ProcessingTypeId = 7
                     }));
         }
 

--- a/Jube.DynamicEnvironment/DynamicEnvironment.cs
+++ b/Jube.DynamicEnvironment/DynamicEnvironment.cs
@@ -61,7 +61,7 @@ public class DynamicEnvironment
             { "SMTPPassword", null },
             { "SMTPFrom", null },
             { "ClickatellAPIKey", null },
-            { "HttpAdaptationUrl", "https://localhost:5001" },
+            { "HttpAdaptationUrl", "http://localhost:5001" },
             { "HttpAdaptationTimeout", "1000" },
             { "HttpAdaptationValidateSsl", "False" },
             { "ReprocessingBulkLimit", "10000" },

--- a/Jube.Engine/EntityAnalysisModelManager.cs
+++ b/Jube.Engine/EntityAnalysisModelManager.cs
@@ -1077,7 +1077,7 @@ public class EntityAnalysisModelManager
 
     private void SyncExhaustiveSearchInstances(DbContext dbContext, Parser.Parser parser)
     {
-        parser.EntityAnalysisModelsAdaptations = [];
+        parser.EntityAnalysisModelsExhaustiveAdaptations = [];
 
         foreach (var (key, value) in ActiveEntityAnalysisModels)
         {
@@ -1204,7 +1204,7 @@ public class EntityAnalysisModelManager
                         Log.Debug(
                             $"Entity Start: Exhaustive GUID {exhaustive.Id} has added {exhaustive.Name} to shadow collection.");
 
-                        parser.EntityAnalysisModelsAdaptations.TryAdd(exhaustive.Name);
+                        parser.EntityAnalysisModelsExhaustiveAdaptations.TryAdd(exhaustive.Name);
 
                         Log.Debug(
                             $"Entity Start: Exhaustive GUID {exhaustive.Id} has added {exhaustive.Name} to parser.");
@@ -1433,7 +1433,7 @@ public class EntityAnalysisModelManager
                     Log.Debug(
                         $"Entity Start: Model {key} and Exhaustive Search Instance Trial Instance ID  {entityAnalysisModelAdaptation.Id} has been added to a shadow list of Adaptations.");
 
-                    parser.EntityAnalysisModelsAdaptations.Add(entityAnalysisModelAdaptation.Name);
+                    parser.EntityAnalysisModelsHttpAdaptations.Add(entityAnalysisModelAdaptation.Name);
 
                     Log.Debug(
                         $"Entity Start: Model {key} and Exhaustive Search Instance Trial Instance ID  {entityAnalysisModelAdaptation.Id} has added {entityAnalysisModelAdaptation.Name} to parser.");

--- a/Jube.Engine/Model/EntityAnalysisModelActivationRule.cs
+++ b/Jube.Engine/Model/EntityAnalysisModelActivationRule.cs
@@ -22,7 +22,8 @@ public class EntityAnalysisModelActivationRule
 {
     public delegate bool Match(Dictionary<string, object> data, Dictionary<string, int> ttlCounter,
         Dictionary<string, double> abstraction,
-        Dictionary<string, double> httpAdaptation, Dictionary<string, double> exhaustiveAdaptation,
+        Dictionary<string, double> httpAdaptation, 
+        Dictionary<string, double> exhaustiveAdaptation,
         Dictionary<string, List<string>> list,
         Dictionary<string, double> calculation,
         Dictionary<string, double> sanctions, Dictionary<string, double> kvp, ILog log);

--- a/Jube.Parser/Parser.cs
+++ b/Jube.Parser/Parser.cs
@@ -27,7 +27,8 @@ public class Parser
     public List<string> EntityAnalysisModelAbstractionCalculations;
     public Dictionary<string, EntityAnalysisModelRequestXPath> EntityAnalysisModelRequestXPaths;
     public List<string> EntityAnalysisModelsAbstractionRule;
-    public List<string> EntityAnalysisModelsAdaptations;
+    public List<string> EntityAnalysisModelsHttpAdaptations;
+    public List<string> EntityAnalysisModelsExhaustiveAdaptations;
     public List<string> EntityAnalysisModelsDictionaries;
     public List<string> EntityAnalysisModelsLists;
     public List<string> EntityAnalysisModelsSanctions;
@@ -49,6 +50,8 @@ public class Parser
         if (!_ruleScriptTokens.Contains("Payload")) _ruleScriptTokens.Add("Payload");
         if (!_ruleScriptTokens.Contains("Abstraction")) _ruleScriptTokens.Add("Abstraction");
         if (!_ruleScriptTokens.Contains("Activation")) _ruleScriptTokens.Add("Activation");
+        if (!_ruleScriptTokens.Contains("ExhaustiveAdaptation")) _ruleScriptTokens.Add("ExhaustiveAdaptation");
+        if (!_ruleScriptTokens.Contains("HttpAdaptation")) _ruleScriptTokens.Add("HttpAdaptation");
         if (!_ruleScriptTokens.Contains("Select")) _ruleScriptTokens.Add("Select");
         if (!_ruleScriptTokens.Contains("Case")) _ruleScriptTokens.Add("Case");
         if (!_ruleScriptTokens.Contains("End Select")) _ruleScriptTokens.Add("End Select");
@@ -70,7 +73,6 @@ public class Parser
 
     public ParsedRule Parse(ParsedRule parsedRule)
     {
-        //var value = new List<ErrorSpan>();
         try
         {
             var lines = parsedRule.ParsedRuleText.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
@@ -80,7 +82,7 @@ public class Parser
             {
                 if (!string.IsNullOrEmpty(line))
                 {
-                    //'Remove strings as they are allowed to have special characters
+                    //Remove strings as they are allowed to have special characters
                     var matches = Regex.Matches(line, "\"(?:[^\"\\\\]|\\\\.)*\"");
 
                     string[] separator =
@@ -94,31 +96,31 @@ public class Parser
                         if (NumericHelper.IsNumeric(tokens[j]))
                             valid = true;
                         else
-                            //'Loop around all permissions,  matching up with the tokens that have been found in the rule text.
+                            //Loop around all permissions,  matching up with the tokens that have been found in the rule text.
                             foreach (var ruleScriptToken in _ruleScriptTokens)
                             {
-                                //'There is a curious case of valid language tokens such a "End If" which is logically a single token,  but would be read as two tokens.  As seen above,  it is possible to store such logical tokens in the registry.
+                                //There is a curious case of valid language tokens such a "End If" which is logically a single token,  but would be read as two tokens.  As seen above,  it is possible to store such logical tokens in the registry.
                                 var permissionTokensCount = ruleScriptToken.Split(" ".ToCharArray()).Length;
-                                //'Find out how many tokens exist inside this token.
+                                //Find out how many tokens exist inside this token.
 
                                 var testToken = "";
                                 int f;
-                                //'This joins up the a token for matching based the next number of tokens
+                                //This joins up the token for matching based the next number of tokens
                                 for (f = 0; f < permissionTokensCount; f++)
                                 {
                                     if (f > 0) testToken += " ";
-                                    var extend = j + f; //'We are adding the tokens that come after.
+                                    var extend = j + f; //We are adding the tokens that come after.
                                     if (extend < tokens.Length) testToken += tokens[extend];
-                                    //'A new test token has been constructed,  for example End If
+                                    //A new test token has been constructed,  for example End If
                                 }
 
                                 if (string.Equals(ruleScriptToken, testToken,
                                         StringComparison.CurrentCultureIgnoreCase))
-                                    //'Check fof the test token (perhaps derived) matches.
+                                    //Check fof the test token (perhaps derived) matches.
                                     valid = true;
                             }
 
-                        if (valid) continue; //'This would be enough to kill the routine, return false.
+                        if (valid) continue; //This would be enough to kill the routine, return false.
                         softParseFailed = true;
 
                         parsedRule.ErrorSpans.Add(new ErrorSpan
@@ -313,7 +315,7 @@ public class Parser
 
         countLine += 1;
         sb.AppendLine(
-            "Public Shared Function Match(Data As Dictionary(Of String, Object),TTLCounter As Dictionary(Of String, Integer),Abstraction As Dictionary(Of String, Double),Adaptation As Dictionary(Of String, Double),List as Dictionary(Of String,List(Of String)),Deviation as Dictionary(Of String, Double),Calculation As Dictionary(Of String, Double),Sanctions As Dictionary(Of String, Double),KVP As Dictionary(Of String, Double),Log as ILog) As Boolean");
+            "Public Shared Function Match(Data As Dictionary(Of String, Object),TTLCounter As Dictionary(Of String, Integer),Abstraction As Dictionary(Of String, Double),HttpAdaptation As Dictionary(Of String, Double),ExhaustiveAdaptation As Dictionary(Of String, Double),List as Dictionary(Of String,List(Of String)),Deviation as Dictionary(Of String, Double),Calculation As Dictionary(Of String, Double),Sanctions As Dictionary(Of String, Double),KVP As Dictionary(Of String, Double),Log as ILog) As Boolean");
 
         countLine += 1;
         sb.AppendLine("Dim Matched as Boolean");
@@ -707,13 +709,13 @@ public class Parser
 
                             replaceString = replaceString + "Calculation(\"" + elements[k] + "\")";
                         }
-                        else if (string.Equals("adaptation", firstString,
+                        else if (string.Equals("exhaustiveAdaptation", firstString,
                                      StringComparison.OrdinalIgnoreCase))
                         {
                             findString = firstString + "." + elements[k];
 
-                            if (EntityAnalysisModelsAdaptations != null)
-                                if (EntityAnalysisModelsAdaptations.All(w => w != elements[k]))
+                            if (EntityAnalysisModelsExhaustiveAdaptations != null)
+                                if (EntityAnalysisModelsExhaustiveAdaptations.All(w => w != elements[k]))
                                 {
                                     var errorSpan = new ErrorSpan
                                     {
@@ -724,8 +726,28 @@ public class Parser
                                     parsedRule.ErrorSpans.Add(errorSpan);
                                 }
 
-                            replaceString = replaceString + "Adaptation(\"" + elements[k] + "\")";
+                            replaceString = replaceString + "ExhaustiveAdaptation(\"" + elements[k] + "\")";
                         }
+                        else if (string.Equals("HTTPAdaptation", firstString,
+                                     StringComparison.OrdinalIgnoreCase))
+                        {
+                            findString = firstString + "." + elements[k];
+
+                            if (EntityAnalysisModelsHttpAdaptations != null)
+                                if (EntityAnalysisModelsHttpAdaptations.All(w => w != elements[k]))
+                                {
+                                    var errorSpan = new ErrorSpan
+                                    {
+                                        Message =
+                                            $"Line {i + 1}: Dictionary does not exist for {elements[k]}.",
+                                        Line = i
+                                    };
+                                    parsedRule.ErrorSpans.Add(errorSpan);
+                                }
+
+                            replaceString = replaceString + "HTTPAdaptation(\"" + elements[k] + "\")";
+                        }
+
                         else if (string.Equals("list", firstString,
                                      StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
There were several legacy issues with the way Adaptation was handled.  In the past Exhaustive and HTTP Adaptation rolled up to the same dictionary in the payload and rule match delegates.  This had the effect of only the HTTP Adaptation working properly when tested.  There was also an error in the completions endpoint that did not return Adaptations at all for Activation Rule creation in the user interface.  In the completions endpoint the error was corrected, and HTTP and Exhaustive Adaptations broken out into separate groups, with that being cascaded to the backend logic also.