### PR TITLE
102 Parsing issue in Reprocessing

### DIFF
--- a/Jube.Engine/EntityAnalysisModelManager/BackgroundTasks/TaskStarters/ReprocessingTaskStarter.cs
+++ b/Jube.Engine/EntityAnalysisModelManager/BackgroundTasks/TaskStarters/ReprocessingTaskStarter.cs
@@ -16,6 +16,7 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Text;
     using System.Threading;
@@ -25,6 +26,7 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
     using Data.Query;
     using Data.Reporting;
     using Data.Repository;
+    using Data.SyntaxTree;
     using Dictionary;
     using EntityAnalysisModel;
     using EntityAnalysisModelInvoke;
@@ -134,9 +136,11 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
                                                 $"Entity Reprocessing: Reprocessing instance {entityAnalysisModelRuleReprocessing.EntityAnalysisModelRuleReprocessingInstance.EntityAnalysisModelsReprocessingRuleInstanceId} is about to run a query on cache to bring back all document for filter,  skipping {processed} and limiting {limit}.");
                                         }
 
+                                        var archivePayloadSelectAndBody = modelKvp.Value.References.ArchivePayloadSqlSelect + " " + modelKvp.Value.References.ArchivePayloadSqlBody;
+                                        
                                         var documents =
                                             await archiveDatabase.ExecuteReturnPayloadFromArchiveWithSkipLimitAsync(
-                                                modelKvp.Value.References.ArchivePayloadSql, dateRangeAndCount.adjustedStartDate,
+                                                archivePayloadSelectAndBody, dateRangeAndCount.adjustedStartDate,
                                                 processed,
                                                 limit, context.Services.TaskCoordinator.CancellationToken).ConfigureAwait(false);
 
@@ -601,7 +605,7 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
 
             try
             {
-                var (key, _) = modelKvp;
+                var (key, entityAnalysisModel) = modelKvp;
                 if (context.Services.Log.IsDebugEnabled)
                 {
                     context.Services.Log.Debug(
@@ -723,7 +727,31 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
                             $"Entity Reprocessing:  Has found model id {key}.  Is loading the rule parser and tokens.");
                     }
 
-                    var parser = new Parser(context.Services.Log, []);
+                    var parser = new Parser(context.Services.Log, [])
+                    {
+                        EntityAnalysisModelRequestXPaths = [],
+                        EntityAnalysisModelInlineScriptProperties = []
+                    };
+
+                    foreach (var entityAnalysisModelRequestXPath in
+                             entityAnalysisModel.Collections.EntityAnalysisModelRequestXPaths
+                                 .Where(entityAnalysisModelRequestXPath => !parser.EntityAnalysisModelRequestXPaths.ContainsKey(entityAnalysisModelRequestXPath.Name)))
+                    {
+                        parser.EntityAnalysisModelRequestXPaths.Add(entityAnalysisModelRequestXPath.Name,
+                            new EntityAnalysisModelRequestXPath
+                            {
+                                DataTypeId = entityAnalysisModelRequestXPath.DataTypeId,
+                                DefaultValue = entityAnalysisModelRequestXPath.DefaultValue
+                            });
+                    }
+
+                    foreach (var publicProperty in
+                             entityAnalysisModel.Collections.EntityAnalysisModelInlineScripts
+                                 .SelectMany(entityAnalysisModelInlineScript
+                                     => SyntaxTreeHelpers.GetPublicProperties(entityAnalysisModelInlineScript.InlineScriptCode, entityAnalysisModelInlineScript.LanguageId == 2)))
+                    {
+                        parser.EntityAnalysisModelInlineScriptProperties.TryAdd(publicProperty.Key, publicProperty.Value);
+                    }
 
                     if (context.Services.Log.IsDebugEnabled)
                     {
@@ -739,6 +767,7 @@ namespace Jube.Engine.EntityAnalysisModelManager.BackgroundTasks.TaskStarters
                             OriginalRuleText = record.BuilderRuleScript,
                             ErrorSpans = []
                         };
+
                         parsedRule = parser.TranslateFromDotNotation(parsedRule);
                         parsedRule = parser.Parse(parsedRule);
 

--- a/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Context/Extensions/SyncEntityAnalysisModelInlineScriptsExtensions.cs
+++ b/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Context/Extensions/SyncEntityAnalysisModelInlineScriptsExtensions.cs
@@ -107,6 +107,20 @@ namespace Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Context.Ext
                                 foreach (var publicProperty in SyntaxTreeHelpers.GetPublicProperties(inlineScript.InlineScriptCode, inlineScript.LanguageId == 2))
                                 {
                                     shadowEntityAnalysisModelInlineScriptProperties.TryAdd(publicProperty.Key, publicProperty.Value);
+
+                                    var databaseType = publicProperty.Value switch
+                                    {
+                                        2 => "::int",
+                                        3 => "::float8",
+                                        4 => "::timestamp",
+                                        5 => "::boolean",
+                                        6 => "::float8",
+                                        7 => "::float8",
+                                        _ => ""
+                                    };
+                                    
+                                    value.References.ArchivePayloadSqlSelect +=
+                                        $",(a.\"Json\" -> 'payload' ->> '{publicProperty.Key}'){databaseType} AS \"{publicProperty.Key}\"";
                                 }
 
                                 if (context.Services.Log.IsDebugEnabled)

--- a/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Context/Extensions/SyncEntityAnalysisModelRequestXPathExtensions.cs
+++ b/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Context/Extensions/SyncEntityAnalysisModelRequestXPathExtensions.cs
@@ -50,9 +50,9 @@ namespace Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Context.Ext
                         repository.GetByEntityAnalysisModelIdOrderByIdAsync(key, context.Services.CancellationToken).ConfigureAwait(false);
 
                     var shadowEntityAnalysisModelRequestXPath = new List<Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Models.Models.EntityAnalysisModelRequestXPath>();
-                    var archivePayloadSql = "select a.\"EntityAnalysisModelInstanceEntryGuid\"," +
-                                            "a.\"CreatedDate\"," +
-                                            $"a.\"ReferenceDate\" AS \"{value.References.ReferenceDateName}\"";
+                    var archivePayloadSqlSelect = "select a.\"EntityAnalysisModelInstanceEntryGuid\"," +
+                                                  "a.\"CreatedDate\"," +
+                                                  $"a.\"ReferenceDate\" AS \"{value.References.ReferenceDateName}\"";
 
                     foreach (var record in records)
                     {
@@ -524,7 +524,7 @@ namespace Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Context.Ext
                                 _ => ""
                             };
 
-                            archivePayloadSql +=
+                            archivePayloadSqlSelect +=
                                 $",(a.\"Json\" -> 'payload' ->> '{entityAnalysisModelRequestXPath.Name}'){databaseType} AS \"{entityAnalysisModelRequestXPath.Name}\"";
 
                             shadowEntityAnalysisModelRequestXPath.Add(entityAnalysisModelRequestXPath);
@@ -559,11 +559,12 @@ namespace Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Context.Ext
                         }
                     }
 
-                    value.References.ArchivePayloadSql = archivePayloadSql + " From \"Archive\" a" +
-                                                         " inner join \"EntityAnalysisModel\" m on a.\"EntityAnalysisModelId\" = m.\"Id\"  where "
-                                                         + "m.\"Guid\" = '" + value.Instance.Guid + "'::uuid"
-                                                         + " and \"ReferenceDate\" >= (@adjustedStartDate) " +
-                                                         "order by m.\"Id\" asc limit (@limit) offset (@skip);";
+                    value.References.ArchivePayloadSqlSelect = archivePayloadSqlSelect;
+                    value.References.ArchivePayloadSqlBody = " From \"Archive\" a" +
+                                                             " inner join \"EntityAnalysisModel\" m on a.\"EntityAnalysisModelId\" = m.\"Id\"  where "
+                                                             + "m.\"Guid\" = '" + value.Instance.Guid + "'::uuid"
+                                                             + " and \"ReferenceDate\" >= (@adjustedStartDate) " +
+                                                             "order by m.\"Id\" asc limit (@limit) offset (@skip);";
 
                     value.Collections.EntityAnalysisModelRequestXPaths = shadowEntityAnalysisModelRequestXPath;
                     value.References.PayloadInitialSize = DictionaryNoBoxingHelpers.CalculateInitialSize(value);

--- a/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Models/References.cs
+++ b/Jube.Engine/EntityAnalysisModelManager/EntityAnalysisModel/Models/References.cs
@@ -20,7 +20,8 @@ namespace Jube.Engine.EntityAnalysisModelManager.EntityAnalysisModel.Models
         public string ReferenceDateXpath { get; set; }
         public string ReferenceDateName { get; set; }
         public byte ReferenceDatePayloadLocationTypeId { get; set; }
-        public string ArchivePayloadSql { get; set; }
+        public string ArchivePayloadSqlSelect { get; set; }
+        public string ArchivePayloadSqlBody { get; set; }
         public int PayloadInitialSize { get; set; }
     }
 }

--- a/Jube.Parser/Parser.cs
+++ b/Jube.Parser/Parser.cs
@@ -682,7 +682,7 @@ namespace Jube.Parser
                             {
                                 findString = firstString + "." + elements[k];
 
-                                var asFunction = ".AsString()";
+                                var asFunction = "AsString()";
                                 var databaseCast = "";
                                 var defaultValue = "";
                                 if (EntityAnalysisModelRequestXPaths != null || EntityAnalysisModelInlineScriptProperties != null)


### PR DESCRIPTION
Reprocessing bug fixes:

* Refactored Archive SQL generation and fixed parse compilation. Separated the Archive query into a SELECT section (handling Request XPath and Inline Script properties), and a block for table definitions and predication.
* Updated the structure to allow select components to be built across multiple synchronization steps.
* Fixed compilation error for VB.net fragment by correcting the fallback value in parse from .AsString() to AsString() to resolve a syntax-induced build failure.