### PR TITLE
125 When EnableEngine is False in the environment variables ready endpoint fails

### DIFF
--- a/Jube.App/Controllers/Health/ReadyController.cs
+++ b/Jube.App/Controllers/Health/ReadyController.cs
@@ -30,7 +30,7 @@ namespace Jube.App.Controllers.Health
         private readonly IHostApplicationLifetime lifetime;
 
         public ReadyController(IHostApplicationLifetime lifetime,
-            DynamicEnvironment dynamicEnvironment, Engine engine, Relay relay = null)
+            DynamicEnvironment dynamicEnvironment, Engine engine = null, Relay relay = null)
         {
             this.engine = engine;
             this.relay = relay;
@@ -45,7 +45,7 @@ namespace Jube.App.Controllers.Health
             {
                 return Task.FromResult<ActionResult>(StatusCode(503));
             }
-            
+
             if (dynamicEnvironment.AppSettings("EnableEngine").Equals("True"))
             {
                 if (engine.Context is not { Ready: true })


### PR DESCRIPTION
In the ReadyController made the Engine instance optional for the constructor, as it was failing on the EnableEngine environment variable being False.