### PR TITLE
Prevent browser autofill on hidden password reset fields

### DIFF
--- a/Jube.App/Pages/Account/Login.cshtml
+++ b/Jube.App/Pages/Account/Login.cshtml
@@ -70,33 +70,36 @@
     <button id="Login" type="submit">Log in</button>
     <span id="MessageAuthenticate"></span>
 </div>
-<div id="PasswordResetDiv">
-    <form id="FormChange">
+<template id="PasswordResetTemplate">
+    <div id="PasswordResetDiv">
+        <form id="FormChange">
+            <br/>
+            <table id="PasswordResetTable" class="tTStyle">
+                <tr>
+                    <td>
+                        <label for="NewPassword">New Password</label>
+                    </td>
+                    <td>
+                        <input type="password" id="NewPassword" name="NewPassword" class="k-textbox" autocomplete="new-password">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="VerifyNewPassword">Verify New Password</label>
+                    </td>
+                    <td>
+                        <input type="password" id="VerifyNewPassword" name="VerifyNewPassword" class="k-textbox" autocomplete="new-password">
+                    </td>
+                </tr>
+            </table>
+        </form>
         <br/>
-        <table id="PasswordResetTable" class="tTStyle">
-            <tr>
-                <td>
-                    <label for="NewPassword">New Password</label>
-                </td>
-                <td>
-                    <input type="password" id="NewPassword" name="NewPassword" class="k-textbox">
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="VerifyNewPassword">Verify New Password</label>
-                </td>
-                <td>
-                    <input type="password" id="VerifyNewPassword" name="VerifyNewPassword" class="k-textbox">
-                </td>
-            </tr>
-        </table>
-    </form>
-    <br/>
-    <div class="topPaddedGeneral">
-        <button id="Change" type="submit">Change Password and Login</button> <span id="MessageChange"></span>
+        <div class="topPaddedGeneral">
+            <button id="Change" type="submit">Change Password and Login</button> <span id="MessageChange"></span>
+        </div>
     </div>
-</div>
+</template>
+<div id="PasswordResetContainer"></div>
 @if (sandpit)
 {
     <hr/>

--- a/Jube.App/wwwroot/js/Account/Authentication.js
+++ b/Jube.App/wwwroot/js/Account/Authentication.js
@@ -12,6 +12,7 @@
  */
 
 var isChange;
+var passwordResetRendered = false;
 
 $(document).ready(function () {
     $("#FormAuthenticate").kendoValidator({
@@ -66,12 +67,36 @@ $(document).ready(function () {
                     document.location.replace("/");
                 },
                 403: function (response) {
+                    if (!passwordResetRendered) {
+                        passwordResetRendered = true;
+                        $("#PasswordResetContainer").append($("#PasswordResetTemplate").prop("content").cloneNode(true));
+                        $("#FormChange").kendoValidator({
+                            errorTemplate: "<span class='errorMessage'>#=message#</span>",
+                            rules: {
+                                verifyPasswords: function (input) {
+                                    if (input.is("#VerifyNewPassword")) {
+                                        return input.val() === $("#NewPassword").val();
+                                    }
+                                    return true;
+                                }
+                            }
+                        });
+                        $("#Change").kendoButton({
+                            click: function (e) {
+                                if ($("#FormChange").data("kendoValidator").validate()) {
+                                    $("#MessageChange").css('color', 'green');
+                                    $("#MessageChange").html("Changing.");
+                                    $("#MessageServerValidation").hide();
+                                    $("#Change").data("kendoButton").enable(false);
+                                    PostAuthentication();
+                                }
+                            }
+                        });
+                    }
                     $("#MessageAuthenticate").html("green");
                     $("#MessageAuthenticate").html("Password must be changed.");
                     $("#UserName").attr("disabled", "disabled");
                     $("#Password").attr("disabled", "disabled");
-                    $("#PasswordResetDiv").show();
-                    $("#Change").show();
                     isChange = true;
                 },
                 401: function (response) {


### PR DESCRIPTION
- `#PasswordResetDiv` was rendered in the DOM on page load and hidden via JavaScript, allowing browser autofill to silently fill `#NewPassword` with saved credentials   
- Moved `PasswordResetDiv` into a `<template>` element so inputs are fully absent from the DOM until a 403 response is received                                            
- Kendo validator and button are initialized lazily on first 403, guarded by `passwordResetRendered` flag to prevent duplicate DOM elements on repeated attempts

Closes #141 