### PR TITLE
Bugfix/activation rule priority

### DIFF
--- a/Jube.App/Dto/EntityAnalysisModelActivationRuleDto.cs
+++ b/Jube.App/Dto/EntityAnalysisModelActivationRuleDto.cs
@@ -22,6 +22,7 @@ namespace Jube.App.Dto
         public string BuilderRuleScript { get; set; }
         public string Json { get; set; }
         public string Name { get; set; }
+        public double Priority { get; set; }
         public double ResponseElevation { get; set; }
         public Guid CaseWorkflowGuid { get; set; }
         public bool EnableCaseWorkflow { get; set; }

--- a/Jube.App/Validators/EntityAnalysisModelActivationRuleDtoValidator.cs
+++ b/Jube.App/Validators/EntityAnalysisModelActivationRuleDtoValidator.cs
@@ -40,6 +40,7 @@ namespace Jube.App.Validators
             RuleFor(p => p.EntityAnalysisModelId).GreaterThan(0);
             RuleFor(p => p.Active).NotNull();
             RuleFor(p => p.Locked).NotNull();
+            RuleFor(p => p.Priority).GreaterThanOrEqualTo(0);
 
             var reviewStatusTypes = new List<int>
             {

--- a/Jube.App/wwwroot/js/Administration/Frame/VisualisationRegistryDatasource.js
+++ b/Jube.App/wwwroot/js/Administration/Frame/VisualisationRegistryDatasource.js
@@ -42,7 +42,8 @@ var includeDisplay = $("#IncludeDisplay").kendoSwitch({
 var priority = $("#Priority").kendoNumericTextBox({
     format: "n1",
     decimals: 1,
-    step: 0.1
+    step: 0.1,
+    min: 0
 });
 
 function changeVisualisationType() {

--- a/Jube.App/wwwroot/js/Model/Frame/EntityAnalysisModelActivationRule.js
+++ b/Jube.App/wwwroot/js/Model/Frame/EntityAnalysisModelActivationRule.js
@@ -126,7 +126,8 @@ var responseElevation = $("#ResponseElevation").kendoNumericTextBox();
 var priority = $("#Priority").kendoNumericTextBox({
     format: "n1",
     decimals: 1,
-    step: 0.1
+    step: 0.1,
+    min: 0
 });
 
 var bypassSuspendSample = $("#BypassSuspendSample").kendoSlider({

--- a/Jube.App/wwwroot/js/Model/Frame/EntityAnalysisModelGatewayRule.js
+++ b/Jube.App/wwwroot/js/Model/Frame/EntityAnalysisModelGatewayRule.js
@@ -18,7 +18,8 @@ var validationFail = "There is invalid data in the form. Please check fields and
 var priority = $("#Priority").kendoNumericTextBox({
     format: "n1",
     decimals: 1,
-    step: 0.1
+    step: 0.1,
+    min: 0
 });
 
 var gatewaySample = $("#GatewaySample").kendoSlider({


### PR DESCRIPTION
## Summary

This PR fixes activation-rule priority persistence and prevents negative priority values in JUBE.

## Root cause

The activation-rule frontend was already sending `priority`, but `EntityAnalysisModelActivationRuleDto` did not contain the `Priority` property. The backend therefore discarded the value, causing it to return to `0` after saving.

## Changes

- Added `Priority` to `EntityAnalysisModelActivationRuleDto`.
- Added backend validation requiring Priority to be `0` or greater.
- Added `min: 0` to the frontend Priority controls for:
  - Activation Rules
  - Gateway Rules
  - Visualisation Registry Datasources
- Preserved decimal priority values and the existing ascending execution order.

## Validation

- Docker/.NET build completed with 0 errors.
- JavaScript syntax checks passed.
- Priority values now persist after saving.
- Negative values cannot pass frontend or backend validation.
- Existing models and activation rules continued working after deployment.

## Database impact

No database migration or schema change is required because the `Priority` column already exists.