### PR TITLE
Potential fix for code scanning alert no. 95: User-controlled bypass of sensitive method

### DIFF
--- a/Jube.App/Controllers/Authentication/AuthenticationController.cs
+++ b/Jube.App/Controllers/Authentication/AuthenticationController.cs
@@ -261,6 +261,13 @@ namespace Jube.App.Controllers.Authentication
                 return Unauthorized();
             }
 
+            var authenticatedUserName = User.Identity?.Name ?? model.UserName;
+            
+            if (String.IsNullOrEmpty(authenticatedUserName))
+            {
+                return Unauthorized();
+            }
+
             if (dynamicEnvironment.AppSettings("EnableMultifactorAuthentication").Equals("True", StringComparison.OrdinalIgnoreCase))
             {
                 if (String.IsNullOrEmpty(model.Mfa))
@@ -268,17 +275,15 @@ namespace Jube.App.Controllers.Authentication
                     return StatusCode(202);
                 }
 
-                if (model.UserName != null)
+                var mfaResult = await VerifyMfaAsync(authenticatedUserName, model.Mfa, token);
+                
+                if (!mfaResult.IsSuccessful)
                 {
-                    var mfaResult = await VerifyMfaAsync(model.UserName, model.Mfa, token);
-                    if (!mfaResult.IsSuccessful)
-                    {
-                        return Unauthorized();
-                    }
+                    return Unauthorized();
                 }
             }
 
-            var authenticationDto = AuthenticationCookieIssuer.IssueAuthenticationCookies(Response, dynamicEnvironment, model.UserName);
+            var authenticationDto = AuthenticationCookieIssuer.IssueAuthenticationCookies(Response, dynamicEnvironment, authenticatedUserName);
             return Ok(authenticationDto);
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/jube-home/aml-fraud-transaction-monitoring/security/code-scanning/95](https://github.com/jube-home/aml-fraud-transaction-monitoring/security/code-scanning/95)

To fix this, ensure MFA is **always enforced when enabled** and never conditionally skipped based on request-body `model.UserName`.

Best single change (without changing intended functionality):  
- In `ByUserNamePasswordAsync`, after successful `AuthenticateByUserNamePasswordAsync`, derive a trusted username from server state (`User.Identity?.Name`) with fallback to `model.UserName` only for compatibility, and require it to be present before MFA verification/cookie issuance.
- Replace the `if (model.UserName != null)` block so MFA verification is not skipped due to client-controlled null.
- Also use this trusted username when issuing authentication cookies.

Edits are all within `Jube.App/Controllers/Authentication/AuthenticationController.cs` in the shown method region (around lines 264–282). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
