### PR TITLE
Potential fix for code scanning alert no. 96: Insecure randomness

### DIFF
--- a/Jube.LoadTest/LoadRunner.cs
+++ b/Jube.LoadTest/LoadRunner.cs
@@ -16,6 +16,7 @@ namespace Jube.LoadTest
     using System.Collections.Concurrent;
     using System.Diagnostics;
     using System.Net;
+    using System.Security.Cryptography;
     using System.Text;
     using System.Threading.Channels;
 
@@ -112,7 +113,7 @@ namespace Jube.LoadTest
             {
                 while (await timer.WaitForNextTickAsync(durationCts.Token))
                 {
-                    var accountId = keyGenerator?.Next() ?? random.NextInt64(1, settings.KeyPoolSize + 1);
+                    var accountId = keyGenerator?.Next() ?? RandomNumberGenerator.GetInt64(1, settings.KeyPoolSize + 1);
                     var ip = $"{random.Next(1, 255)}.{random.Next(0, 255)}.{random.Next(0, 255)}.{random.Next(1, 255)}";
 
                     var deviceIdBytes = new byte[8];


### PR DESCRIPTION
Potential fix for [https://github.com/jube-home/aml-fraud-transaction-monitoring/security/code-scanning/96](https://github.com/jube-home/aml-fraud-transaction-monitoring/security/code-scanning/96)

Use `System.Security.Cryptography.RandomNumberGenerator` for the flagged `accountId` fallback generation instead of `random.NextInt64(...)`.

Best minimal fix (no functional behavior change beyond stronger RNG):
- In `Jube.LoadTest/LoadRunner.cs`, at the line creating `accountId`, replace:
  - `keyGenerator?.Next() ?? random.NextInt64(1, settings.KeyPoolSize + 1)`
  with:
  - `keyGenerator?.Next() ?? RandomNumberGenerator.GetInt64(1, settings.KeyPoolSize + 1)`
- Add `using System.Security.Cryptography;` in the file’s using block.

This preserves the same range semantics (`[1, KeyPoolSize]`) and keeps all existing logic intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
