### PR TITLE
Fixed case search fan-out by scoping role check to the current tenant.

### DIFF
--- a/Jube.App/Controllers/Session/CompileSql.cs
+++ b/Jube.App/Controllers/Session/CompileSql.cs
@@ -130,8 +130,7 @@ namespace Jube.App.Controllers.Session
             model.SelectSqlSearch = "select " + String.Join(",", columnsSelect);
 
             model.WhereSql = "from \"Case\",\"CaseWorkflow\",\"EntityAnalysisModel\",\"TenantRegistry\"," +
-                             "\"CaseWorkflowStatus\",\"UserInTenant\",\"CaseWorkflowRole\",\"CaseWorkflowStatusRole\"," +
-                             "(select \"RoleRegistry\".\"Guid\" from \"RoleRegistry\",\"UserRegistry\" where \"RoleRegistry\".\"Guid\" = \"UserRegistry\".\"RoleRegistryGuid\" and (\"RoleRegistry\".\"Deleted\" = 0 or \"RoleRegistry\".\"Deleted\" IS NULL) and \"UserRegistry\".\"Name\" = (@" + positionUser + ")) \"RoleRegistry\"" +
+                             "\"CaseWorkflowStatus\",\"UserInTenant\"" +
                              " where \"EntityAnalysisModel\".\"Id\" = \"CaseWorkflow\".\"EntityAnalysisModelId\"" +
                              " and \"EntityAnalysisModel\".\"TenantRegistryId\" = \"TenantRegistry\".\"Id\"" +
                              " and \"UserInTenant\".\"TenantRegistryId\" = \"TenantRegistry\".\"Id\"" +
@@ -140,8 +139,22 @@ namespace Jube.App.Controllers.Session
                              " and (\"CaseWorkflowStatus\".\"Deleted\" = 0" +
                              " or \"CaseWorkflowStatus\".\"Deleted\" IS null) ) and " + filterRule.Sql +
                              " and (\"CaseWorkflow\".\"Guid\" = uuid(@" + positionCaseWorkflowGuid + ") " +
-                             " and (\"CaseWorkflowRole\".\"CaseWorkflowGuid\" = \"CaseWorkflow\".\"Guid\" and \"CaseWorkflowRole\".\"RoleRegistryGuid\" = \"RoleRegistry\".\"Guid\" and (\"CaseWorkflowRole\".\"Deleted\" = 0 or \"CaseWorkflowRole\".\"Deleted\" IS NULL)) " +
-                             " and (\"CaseWorkflowStatusRole\".\"CaseWorkflowStatusGuid\" = \"CaseWorkflowStatus\".\"Guid\" and \"CaseWorkflowStatusRole\".\"RoleRegistryGuid\" = \"RoleRegistry\".\"Guid\" and (\"CaseWorkflowStatusRole\".\"Deleted\" = 0 or \"CaseWorkflowStatusRole\".\"Deleted\" IS NULL)) " +
+                             " and exists (select 1 from \"CaseWorkflowRole\",\"RoleRegistry\",\"UserRegistry\"" +
+                             " where \"CaseWorkflowRole\".\"CaseWorkflowGuid\" = \"CaseWorkflow\".\"Guid\"" +
+                             " and \"CaseWorkflowRole\".\"RoleRegistryGuid\" = \"RoleRegistry\".\"Guid\"" +
+                             " and (\"CaseWorkflowRole\".\"Deleted\" = 0 or \"CaseWorkflowRole\".\"Deleted\" IS NULL)" +
+                             " and \"RoleRegistry\".\"Guid\" = \"UserRegistry\".\"RoleRegistryGuid\"" +
+                             " and \"RoleRegistry\".\"TenantRegistryId\" = \"TenantRegistry\".\"Id\"" +
+                             " and (\"RoleRegistry\".\"Deleted\" = 0 or \"RoleRegistry\".\"Deleted\" IS NULL)" +
+                             " and \"UserRegistry\".\"Name\" = (@" + positionUser + ")) " +
+                             " and exists (select 1 from \"CaseWorkflowStatusRole\",\"RoleRegistry\",\"UserRegistry\"" +
+                             " where \"CaseWorkflowStatusRole\".\"CaseWorkflowStatusGuid\" = \"CaseWorkflowStatus\".\"Guid\"" +
+                             " and \"CaseWorkflowStatusRole\".\"RoleRegistryGuid\" = \"RoleRegistry\".\"Guid\"" +
+                             " and (\"CaseWorkflowStatusRole\".\"Deleted\" = 0 or \"CaseWorkflowStatusRole\".\"Deleted\" IS NULL)" +
+                             " and \"RoleRegistry\".\"Guid\" = \"UserRegistry\".\"RoleRegistryGuid\"" +
+                             " and \"RoleRegistry\".\"TenantRegistryId\" = \"TenantRegistry\".\"Id\"" +
+                             " and (\"RoleRegistry\".\"Deleted\" = 0 or \"RoleRegistry\".\"Deleted\" IS NULL)" +
+                             " and \"UserRegistry\".\"Name\" = (@" + positionUser + ")) " +
                              " and (\"CaseWorkflow\".\"Deleted\" = 0 or \"CaseWorkflow\".\"Deleted\" is null))" +
                              " and \"UserInTenant\".\"User\" = (@" + positionUser + ")";
 


### PR DESCRIPTION
Fixed case search fan-out by scoping role check to the current tenant. CompileAsync built the case-search WHERE clause with a derived "RoleRegistry" table that resolved the caller's role by UserRegistry.Name alone, with no tenant predicate. UserRegistry rows are not unique per username across tenants (the same login can belong to multiple tenants via UserInTenant), so a user in more than one tenant could get back more than one RoleRegistry.Guid here. That fed the CaseWorkflowRole/CaseWorkflowStatusRole join predicates, which are junction tables (one row per workflow/status x granted role). Each extra role match multiplied the Case row in the joined result, producing duplicate cases in the search results, sourced from role grants in other tenants.

SessionCaseSearchCompiledSqlController's limit-100 query has no DISTINCT, so the duplicates could also crowd out genuinely distinct cases within a page. 

Moved the CaseWorkflowRole/CaseWorkflowStatusRole/RoleRegistry checks out of the joined FROM list and into EXISTS subqueries correlated to the current CaseWorkflow/CaseWorkflowStatus/TenantRegistry, matching the EXISTS-based permission-check pattern already used elsewhere (GetCaseByIdQuery, GetCaseByCaseKeyValueQuery, etc.). Role matches can no longer multiply the outer Case row regardless of how many tenants or roles the user holds. 

Not reproduced locally; but matched a known fan-out/duplicate-case pattern seen before. Have verified this fix against a live case search.