### PR TITLE
Upgraded all Jube and vendored Accord projects from .NET 9 to .NET 10, with the accompanying API, dependency, and linter fixes needed to build clean.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*.cs]
+dotnet_naming_style.camel_case.capitalization  = camel_case
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_symbols.constant_fields.applicable_kinds       = field
+dotnet_naming_symbols.constant_fields.required_modifiers     = const
+dotnet_naming_rule.constants_are_pascal_case.symbols         = constant_fields
+dotnet_naming_rule.constants_are_pascal_case.style           = pascal_case
+dotnet_naming_rule.constants_are_pascal_case.severity        = suggestion
+dotnet_naming_symbols.non_public_fields.applicable_kinds            = field
+dotnet_naming_symbols.non_public_fields.applicable_accessibilities  = private, internal, private_protected
+dotnet_naming_rule.non_public_fields_are_camel_case.symbols         = non_public_fields
+dotnet_naming_rule.non_public_fields_are_camel_case.style           = camel_case
+dotnet_naming_rule.non_public_fields_are_camel_case.severity        = suggestion
+
+[Accord.*/**.cs]
+dotnet_naming_rule.constants_are_pascal_case.severity        = none
+dotnet_naming_rule.non_public_fields_are_camel_case.severity = none

--- a/Accord.Core/Accord.Core.csproj
+++ b/Accord.Core/Accord.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <DefaultItemExcludes>Properties\**;$(DefaultItemExcludes)</DefaultItemExcludes>

--- a/Accord.Genetic/Accord.Genetic.csproj
+++ b/Accord.Genetic/Accord.Genetic.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <AssemblyName>Accord.Genetic</AssemblyName>
         <RootNamespace>Accord.Genetic</RootNamespace>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 

--- a/Accord.MachineLearning/Accord.MachineLearning.csproj
+++ b/Accord.MachineLearning/Accord.MachineLearning.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <AssemblyName>Accord.MachineLearning</AssemblyName>
         <RootNamespace>Accord.MachineLearning</RootNamespace>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 

--- a/Accord.Math.Core/Accord.Math.Core.csproj
+++ b/Accord.Math.Core/Accord.Math.Core.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <DefaultItemExcludes>Properties/**;$(DefaultItemExcludes)</DefaultItemExcludes>

--- a/Accord.Math/Accord.Math.csproj
+++ b/Accord.Math/Accord.Math.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Accord.Neuro/Accord.Neuro.csproj
+++ b/Accord.Neuro/Accord.Neuro.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <AssemblyName>Accord.Neuro</AssemblyName>
         <RootNamespace>Accord.Neuro</RootNamespace>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 

--- a/Accord.Statistics/Accord.Statistics.csproj
+++ b/Accord.Statistics/Accord.Statistics.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefaultItemExcludes>Properties/**;$(DefaultItemExcludes)</DefaultItemExcludes>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Jube.'))">
+        <!-- Transitive version pin, not a code dependency: log4net and
+             FluentMigrator.Runner.SqlServerCe drag in System.Drawing.Common 4.7.0
+             (NU1904, critical). This forces the resolved version to a patched one. -->
+        <PackageReference Include="System.Drawing.Common" Version="10.0.11"/>
+    </ItemGroup>
+</Project>

--- a/Jube.ApiTokensCache/Jube.ApiTokensCache.csproj
+++ b/Jube.ApiTokensCache/Jube.ApiTokensCache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Jube.ApiTokensCache</RootNamespace>

--- a/Jube.App/Controllers/Session/SessionCaseSearchCompiledSqlController.cs
+++ b/Jube.App/Controllers/Session/SessionCaseSearchCompiledSqlController.cs
@@ -15,6 +15,7 @@ namespace Jube.App.Controllers.Session
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,6 @@ namespace Jube.App.Controllers.Session
     using Dto;
     using Dto.Mapping;
     using DynamicEnvironment;
-    using FluentMigrator.Runner;
     using FluentValidation;
     using FluentValidation.Results;
     using log4net;
@@ -120,7 +120,7 @@ namespace Jube.App.Controllers.Session
 
                 var tokens = JsonConvert.DeserializeObject<List<object>>(model.FilterTokens);
 
-                var sw = new StopWatch();
+                var sw = new Stopwatch();
                 sw.Start();
 
                 var value = await postgres.ExecuteByOrderedParametersAsync(model.SelectSqlSearch
@@ -134,7 +134,7 @@ namespace Jube.App.Controllers.Session
                 {
                     SessionCaseSearchCompiledSqlId = model.Id,
                     Records = value.Count,
-                    ResponseTime = sw.ElapsedTime().Milliseconds
+                    ResponseTime = sw.Elapsed.Milliseconds
                 };
 
                 var sessionCaseSearchCompiledSqlExecutionRepository =

--- a/Jube.App/Jube.App.csproj
+++ b/Jube.App/Jube.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
         <UserSecretsId>aspnet-JubeUI-1585BC54-1CED-470E-AC35-2C7E8B27EE1F</UserSecretsId>
         <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
@@ -26,7 +26,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.18"/>
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="9.0.13"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.11"/>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="6.0.6"/>
         <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="9.0.13"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>

--- a/Jube.App/Startup.cs
+++ b/Jube.App/Startup.cs
@@ -42,7 +42,6 @@ namespace Jube.App
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.HttpOverrides;
     using Microsoft.AspNetCore.Identity;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -60,13 +59,6 @@ namespace Jube.App
 
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
-        private IConfiguration Configuration { get; }
-
         public void ConfigureServices(IServiceCollection services)
         {
             var cancellationTokenProvider = AddSingletonForCancellationToken(services);
@@ -720,7 +712,7 @@ namespace Jube.App
                         ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
                     };
 
-                    startupOptions.KnownNetworks.Clear();
+                    startupOptions.KnownIPNetworks.Clear();
                     startupOptions.KnownProxies.Clear();
 
                     app.UseForwardedHeaders(startupOptions);

--- a/Jube.CLI/Jube.CLI.csproj
+++ b/Jube.CLI/Jube.CLI.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Cache/Jube.Cache.csproj
+++ b/Jube.Cache/Jube.Cache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/Jube.Cache/Redis/CacheCallbackPublishSubscribe.cs
+++ b/Jube.Cache/Redis/CacheCallbackPublishSubscribe.cs
@@ -156,7 +156,7 @@ namespace Jube.Cache.Redis
                     return;
                 }
 
-                var guid = Guid.Parse(value);
+                var guid = Guid.Parse(value.ToString());
                 Callbacks.TryRemove(guid, out _);
             }
             catch (Exception ex)

--- a/Jube.Cache/Redis/CachePayloadRepository.cs
+++ b/Jube.Cache/Redis/CachePayloadRepository.cs
@@ -206,7 +206,7 @@ namespace Jube.Cache.Redis
                         bulkInsertEntries.Add(new CachePayloadRemovalBatchEntry
                         {
                             CachePayloadRemovalBatchId = cachePayloadRemovalBatch.Id,
-                            EntityAnalysisModelGuid = Guid.Parse(expiredSortedSetEntry.Element),
+                            EntityAnalysisModelGuid = Guid.Parse(expiredSortedSetEntry.Element.ToString()),
                             ReferenceDate = ((long)expiredSortedSetEntry.Score).FromUnixTimeMilliSeconds()
                         });
 

--- a/Jube.Case/Jube.Case.csproj
+++ b/Jube.Case/Jube.Case.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Cryptography/AesEncryption.cs
+++ b/Jube.Cryptography/AesEncryption.cs
@@ -11,69 +11,43 @@
  * see <https://www.gnu.org/licenses/>.
  */
 
-namespace Jube.Cryptography
+namespace Jube.Cryptography;
+
+using System.Security.Cryptography;
+using System.Text;
+
+public enum IvMode
 {
-    using System.Security.Cryptography;
-    using System.Text;
+    Random,
+    Deterministic
+}
 
-    public enum IvMode
+public class AesEncryption(string key, IvMode ivMode = IvMode.Random)
+{
+    public IvMode IvMode { get; } = ivMode;
+
+    private readonly byte[] key =
+        Rfc2898DeriveBytes.Pbkdf2(key, Encoding.UTF8.GetBytes(key), 100_000, HashAlgorithmName.SHA256, 32);
+
+    public string Encrypt(string plainText, IvMode encryptIvMode)
     {
-        Random,
-        Deterministic
-    }
+        using var aes = Aes.Create();
+        aes.Key = key;
 
-    public class AesEncryption
-    {
-        private readonly IvMode ivMode;
-        private readonly byte[] key;
-
-        public AesEncryption(string key, IvMode ivMode = IvMode.Random)
+        if (encryptIvMode == IvMode.Deterministic)
         {
-            using var kdf = new Rfc2898DeriveBytes(key, Encoding.UTF8.GetBytes(key), 100_000, HashAlgorithmName.SHA256);
-            this.key = kdf.GetBytes(32);
-            this.ivMode = ivMode;
+            aes.IV = SHA256.HashData(Encoding.UTF8.GetBytes(plainText))[..16];
         }
 
-        public string Encrypt(string plainText)
+        using var ms = new MemoryStream();
+        ms.Write(aes.IV);
+
+        using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        using (var sw = new StreamWriter(cs))
         {
-            return Encrypt(plainText, ivMode);
+            sw.Write(plainText);
         }
 
-        public string Encrypt(string plainText, IvMode encryptIvMode)
-        {
-            using var aes = Aes.Create();
-            aes.Key = key;
-
-            if (encryptIvMode == IvMode.Deterministic)
-            {
-                aes.IV = SHA256.HashData(Encoding.UTF8.GetBytes(plainText))[..16];
-            }
-
-            using var ms = new MemoryStream();
-            ms.Write(aes.IV);
-
-            using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
-            using (var sw = new StreamWriter(cs))
-            {
-                sw.Write(plainText);
-            }
-
-            return Convert.ToBase64String(ms.ToArray());
-        }
-
-        public string Decrypt(string base64CipherText)
-        {
-            var buffer = Convert.FromBase64String(base64CipherText);
-
-            using var aes = Aes.Create();
-            aes.Key = key;
-            aes.IV = buffer[..16];
-
-            using var ms = new MemoryStream(buffer, 16, buffer.Length - 16);
-            using var cs = new CryptoStream(ms, aes.CreateDecryptor(), CryptoStreamMode.Read);
-            using var sr = new StreamReader(cs);
-
-            return sr.ReadToEnd();
-        }
+        return Convert.ToBase64String(ms.ToArray());
     }
 }

--- a/Jube.Cryptography/JempAesEncryption.cs
+++ b/Jube.Cryptography/JempAesEncryption.cs
@@ -26,12 +26,12 @@ namespace Jube.Cryptography
 
         public JempAesEncryption(string password, string salt, bool legacyFallbackEnabled = false)
         {
-            using var keyDerivationFunction =
-                new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(salt), 100_000, HashAlgorithmName.SHA256);
+            var saltBytes = Encoding.UTF8.GetBytes(salt);
+            var derived = Rfc2898DeriveBytes.Pbkdf2(password, saltBytes, 100_000, HashAlgorithmName.SHA256, 48);
 
-            key = keyDerivationFunction.GetBytes(32);// 256-bit key
-            passwordDerivedLegacyIv = keyDerivationFunction.GetBytes(16);
-            this.salt = Encoding.UTF8.GetBytes(salt);
+            key = derived[..32];
+            passwordDerivedLegacyIv = derived[32..48];
+            this.salt = saltBytes;
             this.legacyFallbackEnabled = legacyFallbackEnabled;
         }
 

--- a/Jube.Cryptography/Jube.Cryptography.csproj
+++ b/Jube.Cryptography/Jube.Cryptography.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Data/Jube.Data.csproj
+++ b/Jube.Data/Jube.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>Jube.Data</AssemblyName>
         <RootNamespace>Jube.Data</RootNamespace>
     </PropertyGroup>
@@ -34,6 +34,8 @@
         </PackageReference>
         <PackageReference Include="AutoMapper" Version="15.1.3"/>
         <PackageReference Include="FluentMigrator.Runner" Version="3.3.2"/>
+        <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.3.2"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3"/>
         <PackageReference Include="Isopoh.Cryptography.Argon2" Version="1.1.12"/>
         <PackageReference Include="linq2db" Version="3.6.0"/>
         <PackageReference Include="log4net" Version="3.3.1"/>

--- a/Jube.Data/Query/CaseQuery/GetCaseBySessionCaseSearchCompileQuery.cs
+++ b/Jube.Data/Query/CaseQuery/GetCaseBySessionCaseSearchCompileQuery.cs
@@ -15,11 +15,11 @@ namespace Jube.Data.Query.CaseQuery
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Context;
     using Dto;
-    using FluentMigrator.Runner;
     using log4net;
     using Newtonsoft.Json;
     using Poco;
@@ -59,7 +59,7 @@ namespace Jube.Data.Query.CaseQuery
 
             var tokens = JsonConvert.DeserializeObject<List<object>>(modelCompiled.FilterTokens);
 
-            var sw = new StopWatch();
+            var sw = new Stopwatch();
             sw.Start();
 
             using var postgres = new Postgres(reportConnectionString, log, parserAssertSelectOnly);
@@ -80,7 +80,7 @@ namespace Jube.Data.Query.CaseQuery
                 {
                     SessionCaseSearchCompiledSqlId = modelCompiled.Id,
                     Records = 1,
-                    ResponseTime = sw.ElapsedTime().Milliseconds
+                    ResponseTime = sw.Elapsed.Milliseconds
                 };
 
                 await sessionCaseSearchCompiledSqlExecutionRepository.InsertAsync(modelInsertNotFound, token);
@@ -97,7 +97,7 @@ namespace Jube.Data.Query.CaseQuery
             {
                 SessionCaseSearchCompiledSqlId = modelCompiled.Id,
                 Records = 1,
-                ResponseTime = sw.ElapsedTime().Milliseconds
+                ResponseTime = sw.Elapsed.Milliseconds
             };
 
             await sessionCaseSearchCompiledSqlExecutionRepository.InsertAsync(modelInsertFound, token);

--- a/Jube.Dictionary/Jube.Dictionary.csproj
+++ b/Jube.Dictionary/Jube.Dictionary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/Jube.DynamicEnvironment/Jube.DynamicEnvironment.csproj
+++ b/Jube.DynamicEnvironment/Jube.DynamicEnvironment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>Jube.DynamicEnvironment</AssemblyName>
         <RootNamespace>Jube.DynamicEnvironment</RootNamespace>
     </PropertyGroup>

--- a/Jube.Engine/Jube.Engine.csproj
+++ b/Jube.Engine/Jube.Engine.csproj
@@ -3,7 +3,7 @@
         <AppDesignerFolder>Properties</AppDesignerFolder>
         <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
         <WarningLevel>1</WarningLevel>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AsyncFixer" Version="1.6.0">
@@ -16,22 +16,14 @@
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.10.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0"/>
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
         <PackageReference Include="RabbitMQ.Client" Version="6.2.1"/>
-        <PackageReference Include="System.Buffers" Version="4.5.1"/>
         <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0"/>
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1"/>
-        <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"/>
-        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0"/>
-        <PackageReference Include="System.Runtime" Version="4.3.0"/>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
-        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0"/>
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="Class1.cs"/>

--- a/Jube.Extensions/Jube.Extensions.csproj
+++ b/Jube.Extensions/Jube.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.HealthCheck/Jube.HealthCheck.csproj
+++ b/Jube.HealthCheck/Jube.HealthCheck.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.HttpAdaptationProtocol/Jube.HttpAdaptationProtocol.csproj
+++ b/Jube.HttpAdaptationProtocol/Jube.HttpAdaptationProtocol.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Jube.HttpHeaders/Jube.HttpHeaders.csproj
+++ b/Jube.HttpHeaders/Jube.HttpHeaders.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.LoadTest/Jube.LoadTest.csproj
+++ b/Jube.LoadTest/Jube.LoadTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Jube.LoadTest</RootNamespace>

--- a/Jube.Mfa/Jube.Mfa.csproj
+++ b/Jube.Mfa/Jube.Mfa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Migrations/Branches/GitHubIssueBranch139/BackfillTtlCounterEntryExpiryIndex.cs
+++ b/Jube.Migrations/Branches/GitHubIssueBranch139/BackfillTtlCounterEntryExpiryIndex.cs
@@ -66,7 +66,7 @@ namespace Jube.Migrations.Branches.GitHubIssueBranch139
 
             foreach (var hashEntry in cacheService.ResilientRedisResilientRedisDatabase.HashScan(redisKey))
             {
-                if (!Int64.TryParse(hashEntry.Name, out var timestamp))
+                if (!long.TryParse(hashEntry.Name.ToString(), out var timestamp))
                 {
                     continue;
                 }

--- a/Jube.Migrations/Branches/GitHubIssueBranch84.cs
+++ b/Jube.Migrations/Branches/GitHubIssueBranch84.cs
@@ -228,7 +228,7 @@ namespace Jube.Migrations.Branches
         private void RenameHashKeyForCorrectGuidFormat(HashEntry hashEntry, string redisKeyPayloadCount)
         {
 
-            var guid = Guid.Parse(hashEntry.Name);
+            var guid = Guid.Parse(hashEntry.Name.ToString());
             cacheService.ResilientRedisResilientRedisDatabase?.HashSet(redisKeyPayloadCount, guid.ToString("N"), hashEntry.Value);
             cacheService.ResilientRedisResilientRedisDatabase?.HashDelete(redisKeyPayloadCount, hashEntry.Name);
         }

--- a/Jube.Migrations/Jube.Migrations.csproj
+++ b/Jube.Migrations/Jube.Migrations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,6 +13,7 @@
         <PackageReference Include="FluentMigrator.Extensions.Postgres" Version="3.3.2"/>
         <PackageReference Include="FluentMigrator.Runner" Version="3.3.2"/>
         <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.3.2"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3"/>
         <PackageReference Include="log4net" Version="3.3.1"/>
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="9.0.10"/>
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">

--- a/Jube.Parser/Jube.Parser.csproj
+++ b/Jube.Parser/Jube.Parser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Jube.Preservation/Jube.Preservation.csproj
+++ b/Jube.Preservation/Jube.Preservation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.ResilientNpgsql/Jube.ResilientNpgsql.csproj
+++ b/Jube.ResilientNpgsql/Jube.ResilientNpgsql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Jube.ResilientNpgsqlConnection</RootNamespace>

--- a/Jube.ResilientRedisConnection/Jube.ResilientRedisConnection.csproj
+++ b/Jube.ResilientRedisConnection/Jube.ResilientRedisConnection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Jube.ResilientRedisConnection</RootNamespace>

--- a/Jube.Sandbox/Jube.Sandbox.csproj
+++ b/Jube.Sandbox/Jube.Sandbox.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Service/Jube.Service.csproj
+++ b/Jube.Service/Jube.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.TaskCancellation/Jube.TaskCancellation.csproj
+++ b/Jube.TaskCancellation/Jube.TaskCancellation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Tests/Jube.Tests.csproj
+++ b/Jube.Tests/Jube.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <RootNamespace>Jube.Test</RootNamespace>
@@ -13,7 +13,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Jube.Tokenisation/Jube.Tokenisation.csproj
+++ b/Jube.Tokenisation/Jube.Tokenisation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Jube.Validations/Jube.Validations.csproj
+++ b/Jube.Validations/Jube.Validations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
* Retargeted every project (Jube.* and the vendored Accord.* fork) from net9.0 to net10.0 — no behavioural change intended.
* `Rfc2898DeriveBytes` ctor to `Rfc2898DeriveBytes.Pbkdf2` (SYSLIB0060) — key/IV derivation is byte-for-byte identical.
* `ForwardedHeadersOptions.KnownNetworks` to `KnownIPNetworks` (ASPDEPR005).
* `Guid.Parse` / `long.TryParse` over `RedisValue` / `RedisKey` now need an explicit `.ToString()` to resolve the overload.
* `FluentMigrator.Runner.StopWatch` to `System.Diagnostics.Stopwatch` in the two case-search query paths.
* Dropped package references now provided by the shared framework (`Microsoft.AspNetCore.SignalR.Common`, `Microsoft.VisualBasic`, `System.Buffers`, `System.Runtime.*`, ...) — clears the NU15xx / NU19xx build warnings.
* `Microsoft.NET.Test.Sdk` 16.11.0 to 17.14.1, which removes a vulnerable transitive `Newtonsoft.Json` 9.0.1.
* Pinned `Microsoft.Data.SqlClient` 5.2.3 in Jube.Data / Jube.Migrations — the FluentMigrator 3.3.2 meta runner pulls the SQL Server runners transitively; Jube is Postgres-only so it's unused, but the pin clears its NU1903 (and the transitive `System.IdentityModel.Tokens.Jwt` NU1902).
* Added `Directory.Build.props` as a transitive version pin, not a code dependency — log4net and `FluentMigrator.Runner.SqlServerCe` drag in `System.Drawing.Common` 4.7.0 (NU1904, critical); this forces the resolved version to a patched one.
* Added `.editorconfig` for Rider / ReSharper house-style naming so it stops suggesting `_field`: private and internal fields are camelCase with no prefix, constants are PascalCase; vendored Accord.* is exempt.
* Various little refactors as they cropped up in the linters, in in-scope files only: file-scoped namespaces, primary constructors, and removal of the unused `AesEncryption.Decrypt` / single-arg `Encrypt` overload.
* Solution builds clean on the .NET 10 SDK (0 warnings, 0 errors) and `dotnet list package --vulnerable` reports nothing.